### PR TITLE
TradeSkillMaster: Revived v2.8.3.668

### DIFF
--- a/TradeSkillMaster/ChangeLog.txt
+++ b/TradeSkillMaster/ChangeLog.txt
@@ -1,3 +1,30 @@
+# v2.8.3.668
+
+TradeSkillMaster: Revived
+
+- Release Date: March 23rd, 2023
+- Author: Gnomezilla on Warmane-Icecrown [https://github.com/Bananaman].
+
+
+## Total Time Elapsed Shown After "Full Scan" and "Group Scan" Completion
+
+The "Full Scan" and "Group Scan" features now display the "total time elapsed" in the status bar after completion, such as "Done Scanning (1:35:27)".
+
+This helps players get a better feel for how long each scan takes, and gives people something nice to look at after each scan.
+
+
+## Improved Formatting of the "Full Scan" Time Estimate
+
+We now display the time as `elapsed time / ~estimated total time`, such as `0:15:37 / ~1:41:27`.
+
+The total time estimate is continuously updated during the scan, based on our intelligent, weighted "seconds per page" metric and the total number of pages (which can dynamically change during a scan, when other people post or buy auctions). This "total time estimate" therefore follows the server performance beautifully and is very accurate yet responsive to server performance changes.
+
+It's easier to understand than our previous display of "estimated time remaining", since the server might rapidly send you 10 pages in just a few seconds (which then counted down the "estimated time remaining" very quickly), before suddenly stalling for 30 seconds without any progress. It was still exactly as accurate as the new display method, but the new method is nicer to look at and easier to understand.
+
+
+
+---
+
 # v2.8.3.667
 
 TradeSkillMaster: Revived

--- a/TradeSkillMaster/TradeSkillMaster.toc
+++ b/TradeSkillMaster/TradeSkillMaster.toc
@@ -2,7 +2,7 @@
 ## Title: |cff00fe00TradeSkillMaster: Revived|r
 ## Notes: Core addon for the TradeSkillMaster suite, revived for Wrath of the Lich King. Does nothing without modules installed.
 ## Author: Sapu94, Bart39, Gnomezilla [Warmane-Icecrown(A)], BlueAo [Warmane], andrew6180, Yoshiyuka, DimaSheiko, and other contributors...
-## Version: Rev667
+## Version: Rev668
 ## SavedVariables: TradeSkillMasterAppDB, TradeSkillMasterDB
 ## OptionalDeps: AccurateTime, Ace3, LibDataBroker-1.1, LibDBIcon-1.0, LibExtraTip, TipHelper, LibParse, LibCompress, LibGraph-2.0, SharedMedia, TheUndermineJournal, TheUndermineJournalGE
 ## X-Embeds: AccurateTime, Ace3, LibDataBroker-1.1, LibDBIcon-1.0, LibExtraTip, TipHelper, LibParse, LibCompress, LibGraph-2.0

--- a/TradeSkillMaster/Util/Util.lua
+++ b/TradeSkillMaster/Util/Util.lua
@@ -13,6 +13,25 @@ local private = {}
 TSMAPI:RegisterForTracing(private, "TradeSkillMaster.Util_private")
 
 
+-- Locals to speed up function access.
+local CopyTable = CopyTable
+local error = error
+local floor = floor
+local format = format
+local GetRealmName = GetRealmName
+local gsub = gsub
+local ipairs = ipairs
+local select = select
+local StaticPopup_Show = StaticPopup_Show
+local strfind = strfind
+local strlower = strlower
+local strsub = strsub
+local tinsert = tinsert
+local tremove = tremove
+local type = type
+local UnitName = UnitName
+
+
 --- Shows a popup dialog with the given name and ensures it's visible over the TSM frame by setting the frame strata to TOOLTIP.
 -- @param name The name of the static popup dialog to be shown.
 function TSMAPI:ShowStaticPopupDialog(name)
@@ -97,4 +116,25 @@ end
 
 function TSMAPI:IsPlayer(target)
 	return strlower(target) == strlower(UnitName("player")) or (strfind(target, "-") and strlower(target) == strlower(UnitName("player").."-"..GetRealmName()))
+end
+
+--- Converts seconds into hours, minutes and seconds.
+-- @param seconds Number of seconds. Can be a float (will automatically be rounded down to whole seconds).
+-- NOTE: The return values of this function can be wrapped directly by a call to "TSMAPI:FormatHMS()".
+function TSMAPI:SecondsToHMS(seconds)
+	-- NOTE: This code can be shorter, but was written this way for efficiency.
+	local hours = floor(seconds / 3600)
+	seconds = seconds - (hours * 3600)
+	local minutes = floor(seconds / 60)
+	seconds = floor(seconds - (minutes * 60))
+
+	return hours, minutes, seconds
+end
+
+--- Converts hours, minutes and seconds into a human-readable string.
+-- @param hours Hours. Must be a whole number without decimals.
+-- @param minutes Minutes. Must be a whole number without decimals.
+-- @param seconds Seconds. Must be a whole number without decimals.
+function TSMAPI:FormatHMS(hours, minutes, seconds)
+	return format("%d:%02d:%02d", hours, minutes, seconds)
 end

--- a/TradeSkillMaster_AuctionDB/Modules/Scanning.lua
+++ b/TradeSkillMaster_AuctionDB/Modules/Scanning.lua
@@ -104,14 +104,10 @@ local function FullScanCallback(event, ...)
 			end
 
 			-- Estimate the "remaining time", rounded to the nearest whole second, at least 1 second.
-			local seconds = max(1, floor((pages_remaining * seconds_per_page) + 0.5))
+			local seconds_raw = max(1, floor((pages_remaining * seconds_per_page) + 0.5))
 
 			-- Convert the estimated seconds into hours, minutes and seconds.
-			-- NOTE: This code can be shorter, but was written this way for efficiency.
-			local hours = floor(seconds / 3600)
-			seconds = seconds - (hours * 3600)
-			local minutes = floor(seconds / 60)
-			seconds = seconds - (minutes * 60)
+			local hours, minutes, seconds = TSMAPI:SecondsToHMS(seconds_raw)
 			time_estimate_str = format(" (~%d:%02d:%02d)", hours, minutes, seconds)
 		end
 


### PR DESCRIPTION
TradeSkillMaster: Revived

- Release Date: March 23rd, 2023
- Author: Gnomezilla on Warmane-Icecrown [https://github.com/Bananaman].


## Total Time Elapsed Shown After "Full Scan" and "Group Scan" Completion

The "Full Scan" and "Group Scan" features now display the "total time elapsed" in the status bar after completion, such as "Done Scanning (1:35:27)".

This helps players get a better feel for how long each scan takes, and gives people something nice to look at after each scan.


## Improved Formatting of the "Full Scan" Time Estimate

We now display the time as `elapsed time / ~estimated total time`, such as `0:15:37 / ~1:41:27`.

The total time estimate is continuously updated during the scan, based on our intelligent, weighted "seconds per page" metric and the total number of pages (which can dynamically change during a scan, when other people post or buy auctions). This "total time estimate" therefore follows the server performance beautifully and is very accurate yet responsive to server performance changes.

It's easier to understand than our previous display of "estimated time remaining", since the server might rapidly send you 10 pages in just a few seconds (which then counted down the "estimated time remaining" very quickly), before suddenly stalling for 30 seconds without any progress. It was still exactly as accurate as the new display method, but the new method is nicer to look at and easier to understand.